### PR TITLE
Added SharePoint Sub-Plugin for Microsoft 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@
 <p align="center" style="color:grey;"><i>Get started with Kestra in 4 minutes.</i></p>
 
 
-# Kestra Plugin Template
+# Kestra Microsoft 365 Plugin
 
-> A template for creating Kestra plugins
+> A plugin for interacting with Microsoft 365 services including SharePoint
 
-This repository serves as a general template for creating a new [Kestra](https://github.com/kestra-io/kestra) plugin. It should take only a few minutes! Use this repository as a scaffold to ensure that you've set up the plugin correctly, including unit tests and CI/CD workflows.
+This repository contains the Microsoft 365 plugin for Kestra, which provides tasks for interacting with Microsoft 365 services including SharePoint. The plugin includes tasks for creating, deleting, downloading, exporting, listing, and uploading files in SharePoint document libraries.
 
 ![Kestra orchestrator](https://kestra.io/video.gif)
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ dependencies {
     annotationProcessor group: "io.kestra", name: "processor", version: kestraVersion
     compileOnly group: "io.kestra", name: "core", version: kestraVersion
     compileOnly group: "io.kestra", name: "script", version: kestraVersion
+
+    // Microsoft Graph SDK
+    implementation "com.microsoft.graph:microsoft-graph:5.30.0"
+    implementation "com.azure:azure-identity:1.12.0"
 }
 
 
@@ -172,8 +176,8 @@ jar {
     manifest {
         attributes(
                 "X-Kestra-Name": project.name,
-                "X-Kestra-Title": "Template",
-                "X-Kestra-Group": project.group + ".templates",
+                "X-Kestra-Title": "Microsoft 365",
+                "X-Kestra-Group": project.group + ".microsoft365",
                 "X-Kestra-Description": project.description,
                 "X-Kestra-Version": project.version
         )

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'plugin-template'
+rootProject.name = 'plugin-microsoft365'

--- a/src/main/java/io/kestra/plugin/microsoft365/package-info.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/package-info.java
@@ -1,6 +1,6 @@
 @PluginGroup(
     title = "Microsoft 365",
-    description = "Tasks for interacting with Microsoft 365 services including SharePoint."
+    description = "Tasks for interacting with Microsoft 365 services."
 )
 package io.kestra.plugin.microsoft365;
 

--- a/src/main/java/io/kestra/plugin/microsoft365/package-info.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/package-info.java
@@ -1,0 +1,7 @@
+@PluginGroup(
+    title = "Microsoft 365",
+    description = "Tasks for interacting with Microsoft 365 services including SharePoint."
+)
+package io.kestra.plugin.microsoft365;
+
+import io.kestra.core.models.annotations.PluginGroup;

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Create.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Create.java
@@ -26,7 +26,7 @@ import java.util.Map;
 @NoArgsConstructor
 @Plugin(
     examples = {
-        @io.kestra.core.models.annotations.Example(
+        @Example(
             title = "Create a new file in a SharePoint document library.",
             code = {
                 "siteId: \"your-site-id\"",

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Create.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Create.java
@@ -92,7 +92,7 @@ public class Create extends Task implements RunnableTask<Create.Output> {
             renderedFilename, renderedSiteId, renderedDriveId);
         
         try {
-            com.microsoft.graph.requests.GraphServiceClient<?> graphClient = GraphClientProvider.getClient();
+            GraphServiceClient<?> graphClient = GraphClientProvider.getClient();
             
             DriveItem driveItem = new DriveItem();
             driveItem.name = renderedFilename;

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Create.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Create.java
@@ -1,0 +1,180 @@
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.slf4j.Logger;
+
+import com.microsoft.graph.models.DriveItem;
+import com.microsoft.graph.models.File;
+import com.microsoft.graph.core.ClientException;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Plugin(
+    examples = {
+        @io.kestra.core.models.annotations.Example(
+            title = "Create a new file in a SharePoint document library.",
+            code = {
+                "siteId: \"your-site-id\"",
+                "driveId: \"your-drive-id\"",
+                "parentId: \"your-parent-folder-id\"",
+                "filename: \"example.txt\"",
+                "content: \"File content here\""
+            }
+        )
+    }
+)
+@Schema(
+    title = "Create a new file or folder in a SharePoint document library.",
+    description = "This task allows you to create a new file or folder in a SharePoint document library."
+)
+public class Create extends Task implements RunnableTask<Create.Output> {
+    @Schema(
+        title = "The SharePoint site ID.",
+        description = "The unique identifier of the SharePoint site."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> siteId;
+
+    @Schema(
+        title = "The SharePoint drive ID.",
+        description = "The unique identifier of the SharePoint document library (drive)."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> driveId;
+
+    @Schema(
+        title = "The parent item ID.",
+        description = "The unique identifier of the parent folder where the new item will be created."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> parentId;
+
+    @Schema(
+        title = "The filename or folder name.",
+        description = "The name of the file or folder to create."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> filename;
+
+    @Schema(
+        title = "The content of the file.",
+        description = "The content to be written to the new file. If not provided, an empty folder will be created."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> content;
+
+    @Override
+    public Create.Output run(RunContext runContext) throws Exception {
+        Logger logger = runContext.logger();
+        
+        String renderedSiteId = runContext.render(siteId).as(String.class).orElse(null);
+        String renderedDriveId = runContext.render(driveId).as(String.class).orElse(null);
+        String renderedParentId = runContext.render(parentId).as(String.class).orElse(null);
+        String renderedFilename = runContext.render(filename).as(String.class).orElse(null);
+        String renderedContent = runContext.render(content).as(String.class).orElse(null);
+        
+        logger.debug("Creating file/folder '{}' in SharePoint site '{}', drive '{}'", 
+            renderedFilename, renderedSiteId, renderedDriveId);
+        
+        try {
+            com.microsoft.graph.requests.GraphServiceClient<?> graphClient = GraphClientProvider.getClient();
+            
+            DriveItem driveItem = new DriveItem();
+            driveItem.name = renderedFilename;
+            
+            // If content is provided, create a file; otherwise create a folder
+            if (renderedContent != null) {
+                driveItem.file = new File();
+                driveItem.additionalDataManager().put("@microsoft.graph.conflictBehavior", 
+                    new com.microsoft.graph.core.serialization.AdditionalDataHolder() {
+                        @Override
+                        public Map<String, Object> getAdditionalDataManager() {
+                            return Collections.singletonMap("@microsoft.graph.conflictBehavior", "replace");
+                        }
+                    }.getAdditionalDataManager().get("@microsoft.graph.conflictBehavior"));
+                
+                DriveItem createdItem = graphClient.sites(renderedSiteId)
+                    .drives(renderedDriveId)
+                    .items(renderedParentId)
+                    .children()
+                    .buildRequest()
+                    .post(driveItem);
+                
+                // Upload content to the file
+                graphClient.sites(renderedSiteId)
+                    .drives(renderedDriveId)
+                    .items(createdItem.id)
+                    .content()
+                    .buildRequest()
+                    .put(renderedContent.getBytes());
+                
+                return Output.builder()
+                    .itemId(createdItem.id)
+                    .itemName(createdItem.name)
+                    .uri(new URI("https://graph.microsoft.com/v1.0/sites/" + renderedSiteId + 
+                        "/drives/" + renderedDriveId + "/items/" + createdItem.id))
+                    .build();
+            } else {
+                // Create a folder
+                driveItem.folder = new com.microsoft.graph.models.Folder();
+                
+                DriveItem createdItem = graphClient.sites(renderedSiteId)
+                    .drives(renderedDriveId)
+                    .items(renderedParentId)
+                    .children()
+                    .buildRequest()
+                    .post(driveItem);
+                
+                return Output.builder()
+                    .itemId(createdItem.id)
+                    .itemName(createdItem.name)
+                    .uri(new URI("https://graph.microsoft.com/v1.0/sites/" + renderedSiteId + 
+                        "/drives/" + renderedDriveId + "/items/" + createdItem.id))
+                    .build();
+            }
+        } catch (ClientException e) {
+            logger.error("Failed to create item in SharePoint: {}", e.getMessage());
+            throw new Exception("Failed to create item in SharePoint: " + e.getMessage(), e);
+        } catch (Exception e) {
+            logger.error("Unexpected error while creating item in SharePoint: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "The ID of the created item.",
+            description = "The unique identifier of the created file or folder."
+        )
+        private final String itemId;
+
+        @Schema(
+            title = "The name of the created item.",
+            description = "The name of the created file or folder."
+        )
+        private final String itemName;
+
+        @Schema(
+            title = "The URI of the created item.",
+            description = "The Microsoft Graph API URI of the created item."
+        )
+        private final URI uri;
+    }
+}

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Delete.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Delete.java
@@ -1,0 +1,119 @@
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.slf4j.Logger;
+
+import com.microsoft.graph.core.ClientException;
+
+import java.net.URI;
+import java.util.Map;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Plugin(
+    examples = {
+        @io.kestra.core.models.annotations.Example(
+            title = "Delete a file or folder from a SharePoint document library.",
+            code = {
+                "siteId: \"your-site-id\"",
+                "driveId: \"your-drive-id\"",
+                "itemId: \"your-item-id\""
+            }
+        )
+    }
+)
+@Schema(
+    title = "Delete a file or folder from a SharePoint document library.",
+    description = "This task allows you to delete a file or folder from a SharePoint document library."
+)
+public class Delete extends Task implements RunnableTask<Delete.Output> {
+    @Schema(
+        title = "The SharePoint site ID.",
+        description = "The unique identifier of the SharePoint site."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> siteId;
+
+    @Schema(
+        title = "The SharePoint drive ID.",
+        description = "The unique identifier of the SharePoint document library (drive)."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> driveId;
+
+    @Schema(
+        title = "The item ID.",
+        description = "The unique identifier of the file or folder to delete."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> itemId;
+
+    @Override
+    public Delete.Output run(RunContext runContext) throws Exception {
+        Logger logger = runContext.logger();
+        
+        String renderedSiteId = runContext.render(siteId).as(String.class).orElse(null);
+        String renderedDriveId = runContext.render(driveId).as(String.class).orElse(null);
+        String renderedItemId = runContext.render(itemId).as(String.class).orElse(null);
+        
+        logger.debug("Deleting item '{}' from SharePoint site '{}', drive '{}'", 
+            renderedItemId, renderedSiteId, renderedDriveId);
+        
+        try {
+            com.microsoft.graph.requests.GraphServiceClient<?> graphClient = GraphClientProvider.getClient();
+            
+            // Delete the item
+            graphClient.sites(renderedSiteId)
+                .drives(renderedDriveId)
+                .items(renderedItemId)
+                .buildRequest()
+                .delete();
+            
+            return Output.builder()
+                .itemId(renderedItemId)
+                .uri(new URI("https://graph.microsoft.com/v1.0/sites/" + renderedSiteId + 
+                    "/drives/" + renderedDriveId + "/items/" + renderedItemId))
+                .deleted(true)
+                .build();
+        } catch (ClientException e) {
+            logger.error("Failed to delete item from SharePoint: {}", e.getMessage());
+            throw new Exception("Failed to delete item from SharePoint: " + e.getMessage(), e);
+        } catch (Exception e) {
+            logger.error("Unexpected error while deleting item from SharePoint: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "The ID of the deleted item.",
+            description = "The unique identifier of the deleted file or folder."
+        )
+        private final String itemId;
+
+        @Schema(
+            title = "The URI of the deleted item.",
+            description = "The Microsoft Graph API URI of the deleted item."
+        )
+        private final URI uri;
+
+        @Schema(
+            title = "Whether the item was successfully deleted.",
+            description = "Indicates if the item was successfully deleted."
+        )
+        private final Boolean deleted;
+    }
+}

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Download.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Download.java
@@ -1,0 +1,123 @@
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.slf4j.Logger;
+
+import com.microsoft.graph.core.ClientException;
+
+import java.net.URI;
+import java.util.Map;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Plugin(
+    examples = {
+        @io.kestra.core.models.annotations.Example(
+            title = "Download a file from a SharePoint document library.",
+            code = {
+                "siteId: \"your-site-id\"",
+                "driveId: \"your-drive-id\"",
+                "itemId: \"your-item-id\""
+            }
+        )
+    }
+)
+@Schema(
+    title = "Download the content of a file from a SharePoint document library.",
+    description = "This task allows you to download the content of a file from a SharePoint document library."
+)
+public class Download extends Task implements RunnableTask<Download.Output> {
+    @Schema(
+        title = "The SharePoint site ID.",
+        description = "The unique identifier of the SharePoint site."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> siteId;
+
+    @Schema(
+        title = "The SharePoint drive ID.",
+        description = "The unique identifier of the SharePoint document library (drive)."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> driveId;
+
+    @Schema(
+        title = "The item ID.",
+        description = "The unique identifier of the file to download."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> itemId;
+
+    @Override
+    public Download.Output run(RunContext runContext) throws Exception {
+        Logger logger = runContext.logger();
+        
+        String renderedSiteId = runContext.render(siteId).as(String.class).orElse(null);
+        String renderedDriveId = runContext.render(driveId).as(String.class).orElse(null);
+        String renderedItemId = runContext.render(itemId).as(String.class).orElse(null);
+        
+        logger.debug("Downloading file '{}' from SharePoint site '{}', drive '{}'", 
+            renderedItemId, renderedSiteId, renderedDriveId);
+        
+        try {
+            com.microsoft.graph.requests.GraphServiceClient<?> graphClient = GraphClientProvider.getClient();
+            
+            // Download the file content
+            java.io.InputStream contentStream = graphClient.sites(renderedSiteId)
+                .drives(renderedDriveId)
+                .items(renderedItemId)
+                .content()
+                .buildRequest()
+                .get();
+            
+            // Convert stream to string
+            String fileContent = new String(contentStream.readAllBytes());
+            
+            return Output.builder()
+                .itemId(renderedItemId)
+                .uri(new URI("https://graph.microsoft.com/v1.0/sites/" + renderedSiteId + 
+                    "/drives/" + renderedDriveId + "/items/" + renderedItemId + "/content"))
+                .content(fileContent)
+                .build();
+        } catch (ClientException e) {
+            logger.error("Failed to download file from SharePoint: {}", e.getMessage());
+            throw new Exception("Failed to download file from SharePoint: " + e.getMessage(), e);
+        } catch (Exception e) {
+            logger.error("Unexpected error while downloading file from SharePoint: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "The ID of the downloaded item.",
+            description = "The unique identifier of the downloaded file."
+        )
+        private final String itemId;
+
+        @Schema(
+            title = "The URI of the downloaded item.",
+            description = "The Microsoft Graph API URI of the downloaded item."
+        )
+        private final URI uri;
+
+        @Schema(
+            title = "The content of the downloaded file.",
+            description = "The content of the downloaded file."
+        )
+        private final String content;
+    }
+}

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Export.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Export.java
@@ -1,0 +1,139 @@
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.slf4j.Logger;
+
+import com.microsoft.graph.core.ClientException;
+
+import java.net.URI;
+import java.util.Map;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Plugin(
+    examples = {
+        @io.kestra.core.models.annotations.Example(
+            title = "Export a SharePoint file to PDF format.",
+            code = {
+                "siteId: \"your-site-id\"",
+                "driveId: \"your-drive-id\"",
+                "itemId: \"your-item-id\"",
+                "format: \"pdf\""
+            }
+        )
+    }
+)
+@Schema(
+    title = "Export a file to another format in a SharePoint document library.",
+    description = "This task allows you to export a file to another format (e.g., Office document → PDF) from a SharePoint document library."
+)
+public class Export extends Task implements RunnableTask<Export.Output> {
+    @Schema(
+        title = "The SharePoint site ID.",
+        description = "The unique identifier of the SharePoint site."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> siteId;
+
+    @Schema(
+        title = "The SharePoint drive ID.",
+        description = "The unique identifier of the SharePoint document library (drive)."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> driveId;
+
+    @Schema(
+        title = "The item ID.",
+        description = "The unique identifier of the file to export."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> itemId;
+
+    @Schema(
+        title = "The export format.",
+        description = "The format to export the file to (e.g., pdf, epub, etc.)."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> format;
+
+    @Override
+    public Export.Output run(RunContext runContext) throws Exception {
+        Logger logger = runContext.logger();
+        
+        String renderedSiteId = runContext.render(siteId).as(String.class).orElse(null);
+        String renderedDriveId = runContext.render(driveId).as(String.class).orElse(null);
+        String renderedItemId = runContext.render(itemId).as(String.class).orElse(null);
+        String renderedFormat = runContext.render(format).as(String.class).orElse(null);
+        
+        logger.debug("Exporting file '{}' from SharePoint site '{}', drive '{}' to format '{}'", 
+            renderedItemId, renderedSiteId, renderedDriveId, renderedFormat);
+        
+        try {
+            com.microsoft.graph.requests.GraphServiceClient<?> graphClient = GraphClientProvider.getClient();
+            
+            // Export the file content to the specified format
+            java.io.InputStream contentStream = graphClient.sites(renderedSiteId)
+                .drives(renderedDriveId)
+                .items(renderedItemId)
+                .content()
+                .buildRequest()
+                .get(new com.microsoft.graph.options.QueryOption("format", renderedFormat));
+            
+            // Convert stream to string
+            String exportedContent = new String(contentStream.readAllBytes());
+            
+            return Output.builder()
+                .itemId(renderedItemId)
+                .uri(new URI("https://graph.microsoft.com/v1.0/sites/" + renderedSiteId + 
+                    "/drives/" + renderedDriveId + "/items/" + renderedItemId + "/content?format=" + renderedFormat))
+                .content(exportedContent)
+                .format(renderedFormat)
+                .build();
+        } catch (ClientException e) {
+            logger.error("Failed to export file from SharePoint: {}", e.getMessage());
+            throw new Exception("Failed to export file from SharePoint: " + e.getMessage(), e);
+        } catch (Exception e) {
+            logger.error("Unexpected error while exporting file from SharePoint: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "The ID of the exported item.",
+            description = "The unique identifier of the exported file."
+        )
+        private final String itemId;
+
+        @Schema(
+            title = "The URI of the exported item.",
+            description = "The Microsoft Graph API URI of the exported item."
+        )
+        private final URI uri;
+
+        @Schema(
+            title = "The content of the exported file.",
+            description = "The content of the exported file in the specified format."
+        )
+        private final String content;
+
+        @Schema(
+            title = "The export format.",
+            description = "The format the file was exported to."
+        )
+        private final String format;
+    }
+}

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/GraphClientProvider.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/GraphClientProvider.java
@@ -1,0 +1,54 @@
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import com.azure.identity.ClientSecretCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.microsoft.graph.authentication.TokenCredentialAuthProvider;
+import com.microsoft.graph.requests.GraphServiceClient;
+import java.util.Collections;
+
+public final class GraphClientProvider {
+    private static GraphServiceClient<?> client;
+
+    public static GraphServiceClient<?> getClient() throws SharePointException {
+        if (client == null) {
+            try {
+                // Validate required environment variables
+                String clientId = System.getenv("AZURE_CLIENT_ID");
+                String clientSecret = System.getenv("AZURE_CLIENT_SECRET");
+                String tenantId = System.getenv("AZURE_TENANT_ID");
+                
+                if (clientId == null || clientId.isEmpty()) {
+                    throw new SharePointException("AZURE_CLIENT_ID environment variable is not set or is empty");
+                }
+                if (clientSecret == null || clientSecret.isEmpty()) {
+                    throw new SharePointException("AZURE_CLIENT_SECRET environment variable is not set or is empty");
+                }
+                if (tenantId == null || tenantId.isEmpty()) {
+                    throw new SharePointException("AZURE_TENANT_ID environment variable is not set or is empty");
+                }
+                
+                ClientSecretCredential credential = new ClientSecretCredentialBuilder()
+                    .clientId(clientId)
+                    .clientSecret(clientSecret)
+                    .tenantId(tenantId)
+                    .build();
+
+                TokenCredentialAuthProvider authProvider = new TokenCredentialAuthProvider(
+                    Collections.singletonList("https://graph.microsoft.com/.default"),
+                    credential
+                );
+
+                client = GraphServiceClient.builder()
+                    .authenticationProvider(authProvider)
+                    .buildClient();
+            } catch (Exception e) {
+                if (e instanceof SharePointException) {
+                    throw e;
+                } else {
+                    throw new SharePointException("Failed to initialize Microsoft Graph client: " + e.getMessage(), e);
+                }
+            }
+        }
+        return client;
+    }
+}

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/List.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/List.java
@@ -1,0 +1,190 @@
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.slf4j.Logger;
+
+import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.models.DriveItem;
+import com.microsoft.graph.models.DriveItemCollectionResponse;
+
+import java.net.URI;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Plugin(
+    examples = {
+        @io.kestra.core.models.annotations.Example(
+            title = "List items in a SharePoint document library.",
+            code = {
+                "siteId: \"your-site-id\"",
+                "driveId: \"your-drive-id\"",
+                "itemId: \"your-folder-id\""
+            }
+        )
+    }
+)
+@Schema(
+    title = "List items in a SharePoint document library or folder.",
+    description = "This task allows you to list items in a SharePoint document library or folder."
+)
+public class List extends Task implements RunnableTask<List.Output> {
+    @Schema(
+        title = "The SharePoint site ID.",
+        description = "The unique identifier of the SharePoint site."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> siteId;
+
+    @Schema(
+        title = "The SharePoint drive ID.",
+        description = "The unique identifier of the SharePoint document library (drive)."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> driveId;
+
+    @Schema(
+        title = "The item ID.",
+        description = "The unique identifier of the folder to list items from. If not provided, lists items from the root of the drive."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> itemId;
+
+    @Override
+    public List.Output run(RunContext runContext) throws Exception {
+        Logger logger = runContext.logger();
+        
+        String renderedSiteId = runContext.render(siteId).as(String.class).orElse(null);
+        String renderedDriveId = runContext.render(driveId).as(String.class).orElse(null);
+        String renderedItemId = runContext.render(itemId).as(String.class).orElse(null);
+        
+        logger.debug("Listing items in SharePoint site '{}', drive '{}', folder '{}'", 
+            renderedSiteId, renderedDriveId, renderedItemId);
+        
+        try {
+            com.microsoft.graph.requests.GraphServiceClient<?> graphClient = GraphClientProvider.getClient();
+            
+            // List items in the specified folder or drive root
+            DriveItemCollectionResponse response;
+            if (renderedItemId != null) {
+                response = graphClient.sites(renderedSiteId)
+                    .drives(renderedDriveId)
+                    .items(renderedItemId)
+                    .children()
+                    .buildRequest()
+                    .get();
+            } else {
+                response = graphClient.sites(renderedSiteId)
+                    .drives(renderedDriveId)
+                    .root()
+                    .children()
+                    .buildRequest()
+                    .get();
+            }
+            
+            // Convert DriveItem objects to our Item objects
+            List<Item> items = new ArrayList<>();
+            for (DriveItem driveItem : response.value) {
+                String type = (driveItem.folder != null) ? "folder" : "file";
+                Long size = (driveItem.size != null) ? driveItem.size : 0L;
+                
+                items.add(Item.builder()
+                    .id(driveItem.id)
+                    .name(driveItem.name)
+                    .type(type)
+                    .size(size)
+                    .build());
+            }
+            
+            return Output.builder()
+                .siteId(renderedSiteId)
+                .driveId(renderedDriveId)
+                .itemId(renderedItemId)
+                .uri(new URI("https://graph.microsoft.com/v1.0/sites/" + renderedSiteId + 
+                    "/drives/" + renderedDriveId + "/items/" + (renderedItemId != null ? renderedItemId : "root") + "/children"))
+                .items(items)
+                .build();
+        } catch (ClientException e) {
+            logger.error("Failed to list items in SharePoint: {}", e.getMessage());
+            throw new Exception("Failed to list items in SharePoint: " + e.getMessage(), e);
+        } catch (Exception e) {
+            logger.error("Unexpected error while listing items in SharePoint: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "The SharePoint site ID.",
+            description = "The unique identifier of the SharePoint site."
+        )
+        private final String siteId;
+
+        @Schema(
+            title = "The SharePoint drive ID.",
+            description = "The unique identifier of the SharePoint document library (drive)."
+        )
+        private final String driveId;
+
+        @Schema(
+            title = "The item ID.",
+            description = "The unique identifier of the folder that was listed."
+        )
+        private final String itemId;
+
+        @Schema(
+            title = "The URI of the list operation.",
+            description = "The Microsoft Graph API URI of the list operation."
+        )
+        private final URI uri;
+
+        @Schema(
+            title = "The list of items.",
+            description = "The list of items in the SharePoint document library or folder."
+        )
+        private final List<Item> items;
+    }
+
+    @Builder
+    @Getter
+    public static class Item implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "The ID of the item.",
+            description = "The unique identifier of the item."
+        )
+        private final String id;
+
+        @Schema(
+            title = "The name of the item.",
+            description = "The name of the item."
+        )
+        private final String name;
+
+        @Schema(
+            title = "The type of the item.",
+            description = "The type of the item (file or folder)."
+        )
+        private final String type;
+
+        @Schema(
+            title = "The size of the item.",
+            description = "The size of the item in bytes."
+        )
+        private final Long size;
+    }
+}

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/SharePointException.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/SharePointException.java
@@ -1,0 +1,16 @@
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+
+/**
+ * Custom exception class for SharePoint operations.
+ */
+public class SharePointException extends IllegalVariableEvaluationException {
+    public SharePointException(String message) {
+        super(message);
+    }
+
+    public SharePointException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Upload.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Upload.java
@@ -1,0 +1,202 @@
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.slf4j.Logger;
+
+import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.models.DriveItem;
+import com.microsoft.graph.models.File;
+import com.microsoft.graph.models.UploadSession;
+import com.microsoft.graph.requests.GraphServiceClient;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Plugin(
+    examples = {
+        @io.kestra.core.models.annotations.Example(
+            title = "Upload a file to a SharePoint document library.",
+            code = {
+                "siteId: \"your-site-id\"",
+                "driveId: \"your-drive-id\"",
+                "parentId: \"your-parent-folder-id\"",
+                "filename: \"example.txt\"",
+                "content: \"File content to upload\""
+            }
+        )
+    }
+)
+@Schema(
+    title = "Upload a file to a SharePoint document library.",
+    description = "This task allows you to upload a file to a SharePoint document library. Supports simple upload for files <4MB and chunked upload for larger files."
+)
+public class Upload extends Task implements RunnableTask<Upload.Output> {
+    @Schema(
+        title = "The SharePoint site ID.",
+        description = "The unique identifier of the SharePoint site."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> siteId;
+
+    @Schema(
+        title = "The SharePoint drive ID.",
+        description = "The unique identifier of the SharePoint document library (drive)."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> driveId;
+
+    @Schema(
+        title = "The parent item ID.",
+        description = "The unique identifier of the parent folder where the file will be uploaded."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> parentId;
+
+    @Schema(
+        title = "The filename.",
+        description = "The name of the file to upload."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> filename;
+
+    @Schema(
+        title = "The content of the file.",
+        description = "The content to be uploaded to the file."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> content;
+
+    @Override
+    public Upload.Output run(RunContext runContext) throws Exception {
+        Logger logger = runContext.logger();
+        
+        String renderedSiteId = runContext.render(siteId).as(String.class).orElse(null);
+        String renderedDriveId = runContext.render(driveId).as(String.class).orElse(null);
+        String renderedParentId = runContext.render(parentId).as(String.class).orElse(null);
+        String renderedFilename = runContext.render(filename).as(String.class).orElse(null);
+        String renderedContent = runContext.render(content).as(String.class).orElse(null);
+        
+        logger.debug("Uploading file '{}' to SharePoint site '{}', drive '{}'", 
+            renderedFilename, renderedSiteId, renderedDriveId);
+        
+        try {
+            com.microsoft.graph.requests.GraphServiceClient<?> graphClient = GraphClientProvider.getClient();
+            byte[] contentBytes = renderedContent.getBytes();
+            
+            // For files < 4MB, use simple upload
+            if (contentBytes.length < 4 * 1024 * 1024) {
+                DriveItem driveItem = new DriveItem();
+                driveItem.name = renderedFilename;
+                driveItem.file = new File();
+                driveItem.additionalDataManager().put("@microsoft.graph.conflictBehavior", 
+                    new com.microsoft.graph.core.serialization.AdditionalDataHolder() {
+                        @Override
+                        public Map<String, Object> getAdditionalDataManager() {
+                            return Collections.singletonMap("@microsoft.graph.conflictBehavior", "replace");
+                        }
+                    }.getAdditionalDataManager().get("@microsoft.graph.conflictBehavior"));
+                
+                // Create the file first
+                DriveItem createdItem = graphClient.sites(renderedSiteId)
+                    .drives(renderedDriveId)
+                    .items(renderedParentId)
+                    .children()
+                    .buildRequest()
+                    .post(driveItem);
+                
+                // Upload content to the file
+                graphClient.sites(renderedSiteId)
+                    .drives(renderedDriveId)
+                    .items(createdItem.id)
+                    .content()
+                    .buildRequest()
+                    .put(contentBytes);
+                
+                return Output.builder()
+                    .itemId(createdItem.id)
+                    .itemName(createdItem.name)
+                    .uri(new URI("https://graph.microsoft.com/v1.0/sites/" + renderedSiteId + 
+                        "/drives/" + renderedDriveId + "/items/" + createdItem.id))
+                    .uploaded(true)
+                    .build();
+            } else {
+                // For larger files, use chunked upload
+                // Create upload session
+                UploadSession uploadSession = graphClient.sites(renderedSiteId)
+                    .drives(renderedDriveId)
+                    .items(renderedParentId)
+                    .itemWithPath(renderedFilename)
+                    .createUploadSession(new DriveItem())
+                    .buildRequest()
+                    .post();
+                
+                // Upload file in chunks
+                com.microsoft.graph.requests.LargeFileUploadTask<DriveItem> uploadTask = 
+                    new com.microsoft.graph.requests.LargeFileUploadTask<>(
+                        uploadSession, 
+                        graphClient, 
+                        contentBytes, 
+                        DriveItem.class
+                    );
+                
+                com.microsoft.graph.requests.UploadResult<DriveItem> uploadResult = uploadTask.upload();
+                
+                return Output.builder()
+                    .itemId(uploadResult.itemResponse.id)
+                    .itemName(uploadResult.itemResponse.name)
+                    .uri(new URI("https://graph.microsoft.com/v1.0/sites/" + renderedSiteId + 
+                        "/drives/" + renderedDriveId + "/items/" + uploadResult.itemResponse.id))
+                    .uploaded(true)
+                    .build();
+            }
+        } catch (ClientException e) {
+            logger.error("Failed to upload file to SharePoint: {}", e.getMessage());
+            throw new Exception("Failed to upload file to SharePoint: " + e.getMessage(), e);
+        } catch (Exception e) {
+            logger.error("Unexpected error while uploading file to SharePoint: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "The ID of the uploaded item.",
+            description = "The unique identifier of the uploaded file."
+        )
+        private final String itemId;
+
+        @Schema(
+            title = "The name of the uploaded item.",
+            description = "The name of the uploaded file."
+        )
+        private final String itemName;
+
+        @Schema(
+            title = "The URI of the uploaded item.",
+            description = "The Microsoft Graph API URI of the uploaded item."
+        )
+        private final URI uri;
+
+        @Schema(
+            title = "Whether the file was successfully uploaded.",
+            description = "Indicates if the file was successfully uploaded."
+        )
+        private final Boolean uploaded;
+    }
+}

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/package-info.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/package-info.java
@@ -1,0 +1,8 @@
+@PluginSubGroup(
+    title = "Microsoft 365 SharePoint",
+    description = "Tasks for interacting with SharePoint files and sites.",
+    categories = PluginSubGroup.PluginCategory.STORAGE
+)
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import io.kestra.core.models.annotations.PluginSubGroup;

--- a/src/main/resources/docs/sharepoint-authentication.md
+++ b/src/main/resources/docs/sharepoint-authentication.md
@@ -1,0 +1,139 @@
+# SharePoint Authentication & Permissions
+
+The Microsoft 365 SharePoint plugin uses the **Microsoft Graph SDK for Java** to interact with SharePoint. All tasks require an authenticated Graph client. Authentication is performed via **OAuth2** using Azure AD.
+
+## 1. Register an Azure AD Application
+
+1. Open the Azure portal and navigate to **Azure Active Directory → App registrations**.  
+2. Click **New registration**.  
+   - **Name**: `Kestra SharePoint Plugin` (or any name you prefer).  
+   - **Supported account types**: *Accounts in this organizational directory only* (single tenant) or *Multitenant* as needed.  
+   - **Redirect URI**: `http://localhost` (for development) or your production URL.  
+3. Click **Register**.
+
+## 2. Create a Client Secret
+
+1. In the newly created app, go to **Certificates & secrets**.  
+2. Click **New client secret**.  
+   - Provide a description (e.g., `Kestra secret`).  
+   - Choose an expiration period.  
+3. Click **Add** and **copy** the generated secret value. **You will not be able to see it again.**
+
+## 3. Configure Secrets in Kestra
+
+Kestra reads secrets from its secret store. Define the following secrets (via the UI, `secrets.yml`, or environment variables):
+
+| Secret Key                | Description                                 |
+|---------------------------|---------------------------------------------|
+| `AZURE_TENANT_ID`         | Azure AD tenant ID (directory ID).          |
+| `AZURE_CLIENT_ID`         | Application (client) ID of the registered app. |
+| `AZURE_CLIENT_SECRET`     | The client secret created in step 2.        |
+| `SHAREPOINT_SITE_ID`      | The SharePoint site ID (e.g., `contoso.sharepoint.com,12345`). |
+| `SHAREPOINT_DRIVE_ID`     | The document library (drive) ID.            |
+| `SHAREPOINT_PARENT_ID`    | The folder ID where files will be created/uploaded. |
+| `SHAREPOINT_ITEM_ID`      | The ID of a file or folder (used for delete, download, export). |
+| `SHAREPOINT_FOLDER_ID`    | The ID of a folder to list items from.      |
+
+You can set these secrets in `src/test/resources/application.yml` for local testing, or via the Kestra UI for production.
+
+## 4. Required Permission Scopes
+
+When configuring the Azure AD app, add the following **Microsoft Graph API** permission scopes (Application permissions for service‑to‑service calls, or Delegated permissions for user‑impersonation). The plugin expects **Application** permissions:
+
+| Permission                | Description                                   |
+|---------------------------|-----------------------------------------------|
+| `Sites.Read.All`          | Read all SharePoint sites.                    |
+| `Sites.ReadWrite.All`     | Read and write to all SharePoint sites.       |
+| `Files.Read`              | Read files in all site collections.           |
+| `Files.ReadWrite`         | Read, create, update, and delete files.       |
+| `User.Read`               | Read the profile of the signed‑in user (required for token acquisition). |
+
+After adding the permissions, **grant admin consent** for the tenant.
+
+## 5. Initialising the Graph Client (Java)
+
+Add the Microsoft Graph SDK dependency to `build.gradle`:
+
+```gradle
+dependencies {
+    // existing dependencies ...
+
+    implementation "com.microsoft.graph:microsoft-graph:5.30.0"
+    implementation "com.azure:azure-identity:1.12.0"
+}
+```
+
+Create a utility class to obtain an authenticated `GraphServiceClient`:
+
+```java
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import com.azure.identity.ClientSecretCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.microsoft.graph.authentication.TokenCredentialAuthProvider;
+import com.microsoft.graph.requests.GraphServiceClient;
+import java.util.Collections;
+
+public final class GraphClientProvider {
+    private static GraphServiceClient<?> client;
+
+    public static GraphServiceClient<?> getClient() {
+        if (client == null) {
+            ClientSecretCredential credential = new ClientSecretCredentialBuilder()
+                .clientId(System.getenv("AZURE_CLIENT_ID"))
+                .clientSecret(System.getenv("AZURE_CLIENT_SECRET"))
+                .tenantId(System.getenv("AZURE_TENANT_ID"))
+                .build();
+
+            TokenCredentialAuthProvider authProvider = new TokenCredentialAuthProvider(
+                Collections.singletonList("https://graph.microsoft.com/.default"),
+                credential
+            );
+
+            client = GraphServiceClient.builder()
+                .authenticationProvider(authProvider)
+                .buildClient();
+        }
+        return client;
+    }
+}
+```
+
+## 6. Using the Client in Tasks
+
+Replace the `// TODO: Implement actual SharePoint API call` sections with real calls, for example:
+
+```java
+GraphServiceClient<?> graphClient = GraphClientProvider.getClient();
+
+graphClient.sites(siteId)
+    .drives(driveId)
+    .items(parentId)
+    .children()
+    .buildRequest()
+    .post(new DriveItem()
+        .withName(filename)
+        .withFile(new File())
+        .withAdditionalData(Collections.singletonMap("@microsoft.graph.conflictBehavior", "replace"))
+        .withContent(content.getBytes()));
+```
+
+Each task should handle:
+
+* **Error handling** – catch `GraphServiceException` and translate to meaningful Kestra errors (e.g., permission denied, token expired).  
+* **Large file uploads** – use `createUploadSession` for files > 4 MB, handling chunked uploads.  
+* **Export format** – append `?format={format}` to the download URL.
+
+## 7. Testing
+
+The unit tests provided in `src/test/java/io/kestra/plugin/microsoft365/sharepoint/` use mocked inputs and verify that the task returns non‑null output fields. For integration tests, you can enable the real Graph client by providing valid secrets and running the flow YAML files located in `src/test/resources/flows/sharepoint/`.
+
+## 8. References
+
+* Microsoft Graph SDK for Java: https://github.com/microsoftgraph/msgraph-sdk-java  
+* Azure Identity library: https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/identity/azure-identity  
+* SharePoint API documentation: https://learn.microsoft.com/graph/api/resources/sharepoint?view=graph-rest-1.0  
+
+---
+
+**Note:** The current implementation contains placeholder logic (`TODO` comments) and returns mock data. Replace those sections with the real Graph SDK calls as shown above to achieve full functionality.

--- a/src/test/java/io/kestra/plugin/microsoft365/sharepoint/CreateTest.java
+++ b/src/test/java/io/kestra/plugin/microsoft365/sharepoint/CreateTest.java
@@ -1,0 +1,45 @@
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import org.junit.jupiter.api.Test;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+
+import jakarta.inject.Inject;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * This test will only test the main task, this allow you to send any input
+ * parameters to your task and test the returning behaviour easily.
+ */
+@KestraTest
+class CreateTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void run() throws Exception {
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        Create task = Create.builder()
+            .siteId(new Property<>("test-site-id"))
+            .driveId(new Property<>("test-drive-id"))
+            .parentId(new Property<>("test-parent-id"))
+            .filename(new Property<>("test-file.txt"))
+            .content(new Property<>("Test content"))
+            .build();
+
+        Create.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput, notNullValue());
+        assertThat(runOutput.getItemId(), notNullValue());
+        assertThat(runOutput.getItemName(), is("test-file.txt"));
+        assertThat(runOutput.getUri(), notNullValue());
+    }
+}

--- a/src/test/java/io/kestra/plugin/microsoft365/sharepoint/DeleteTest.java
+++ b/src/test/java/io/kestra/plugin/microsoft365/sharepoint/DeleteTest.java
@@ -1,0 +1,43 @@
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import org.junit.jupiter.api.Test;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+
+import jakarta.inject.Inject;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * This test will only test the main task, this allow you to send any input
+ * parameters to your task and test the returning behaviour easily.
+ */
+@KestraTest
+class DeleteTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void run() throws Exception {
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        Delete task = Delete.builder()
+            .siteId(new Property<>("test-site-id"))
+            .driveId(new Property<>("test-drive-id"))
+            .itemId(new Property<>("test-item-id"))
+            .build();
+
+        Delete.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput, notNullValue());
+        assertThat(runOutput.getItemId(), is("test-item-id"));
+        assertThat(runOutput.getUri(), notNullValue());
+        assertThat(runOutput.getDeleted(), is(true));
+    }
+}

--- a/src/test/java/io/kestra/plugin/microsoft365/sharepoint/DownloadTest.java
+++ b/src/test/java/io/kestra/plugin/microsoft365/sharepoint/DownloadTest.java
@@ -1,0 +1,43 @@
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import org.junit.jupiter.api.Test;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+
+import jakarta.inject.Inject;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * This test will only test the main task, this allow you to send any input
+ * parameters to your task and test the returning behaviour easily.
+ */
+@KestraTest
+class DownloadTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void run() throws Exception {
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        Download task = Download.builder()
+            .siteId(new Property<>("test-site-id"))
+            .driveId(new Property<>("test-drive-id"))
+            .itemId(new Property<>("test-item-id"))
+            .build();
+
+        Download.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput, notNullValue());
+        assertThat(runOutput.getItemId(), is("test-item-id"));
+        assertThat(runOutput.getUri(), notNullValue());
+        assertThat(runOutput.getContent(), notNullValue());
+    }
+}

--- a/src/test/java/io/kestra/plugin/microsoft365/sharepoint/ExportTest.java
+++ b/src/test/java/io/kestra/plugin/microsoft365/sharepoint/ExportTest.java
@@ -1,0 +1,45 @@
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import org.junit.jupiter.api.Test;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+
+import jakarta.inject.Inject;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * This test will only test the main task, this allow you to send any input
+ * parameters to your task and test the returning behaviour easily.
+ */
+@KestraTest
+class ExportTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void run() throws Exception {
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        Export task = Export.builder()
+            .siteId(new Property<>("test-site-id"))
+            .driveId(new Property<>("test-drive-id"))
+            .itemId(new Property<>("test-item-id"))
+            .format(new Property<>("pdf"))
+            .build();
+
+        Export.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput, notNullValue());
+        assertThat(runOutput.getItemId(), is("test-item-id"));
+        assertThat(runOutput.getUri(), notNullValue());
+        assertThat(runOutput.getContent(), notNullValue());
+        assertThat(runOutput.getFormat(), is("pdf"));
+    }
+}

--- a/src/test/java/io/kestra/plugin/microsoft365/sharepoint/ListTest.java
+++ b/src/test/java/io/kestra/plugin/microsoft365/sharepoint/ListTest.java
@@ -1,0 +1,44 @@
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import org.junit.jupiter.api.Test;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+
+import jakarta.inject.Inject;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * This test will only test the main task, this allow you to send any input
+ * parameters to your task and test the returning behaviour easily.
+ */
+@KestraTest
+class ListTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void run() throws Exception {
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        List task = List.builder()
+            .siteId(new Property<>("test-site-id"))
+            .driveId(new Property<>("test-drive-id"))
+            .itemId(new Property<>("test-folder-id"))
+            .build();
+
+        List.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput, notNullValue());
+        assertThat(runOutput.getSiteId(), notNullValue());
+        assertThat(runOutput.getDriveId(), notNullValue());
+        assertThat(runOutput.getUri(), notNullValue());
+        assertThat(runOutput.getItems(), notNullValue());
+    }
+}

--- a/src/test/java/io/kestra/plugin/microsoft365/sharepoint/UploadTest.java
+++ b/src/test/java/io/kestra/plugin/microsoft365/sharepoint/UploadTest.java
@@ -1,0 +1,46 @@
+package io.kestra.plugin.microsoft365.sharepoint;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import org.junit.jupiter.api.Test;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+
+import jakarta.inject.Inject;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * This test will only test the main task, this allow you to send any input
+ * parameters to your task and test the returning behaviour easily.
+ */
+@KestraTest
+class UploadTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void run() throws Exception {
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        Upload task = Upload.builder()
+            .siteId(new Property<>("test-site-id"))
+            .driveId(new Property<>("test-drive-id"))
+            .parentId(new Property<>("test-parent-id"))
+            .filename(new Property<>("test-file.txt"))
+            .content(new Property<>("Test content to upload"))
+            .build();
+
+        Upload.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput, notNullValue());
+        assertThat(runOutput.getItemId(), notNullValue());
+        assertThat(runOutput.getItemName(), notNullValue());
+        assertThat(runOutput.getUri(), notNullValue());
+        assertThat(runOutput.getUploaded(), notNullValue());
+    }
+}

--- a/src/test/resources/flows/sharepoint/create.yaml
+++ b/src/test/resources/flows/sharepoint/create.yaml
@@ -1,0 +1,11 @@
+id: sharepoint-create
+namespace: io.kestra.plugin.microsoft365.sharepoint
+
+tasks:
+  - id: create-file
+    type: io.kestra.plugin.microsoft365.sharepoint.Create
+    siteId: "{{ secret('SHAREPOINT_SITE_ID') }}"
+    driveId: "{{ secret('SHAREPOINT_DRIVE_ID') }}"
+    parentId: "{{ secret('SHAREPOINT_PARENT_ID') }}"
+    filename: "example.txt"
+    content: "This is an example file created by Kestra"

--- a/src/test/resources/flows/sharepoint/delete.yaml
+++ b/src/test/resources/flows/sharepoint/delete.yaml
@@ -1,0 +1,9 @@
+id: sharepoint-delete
+namespace: io.kestra.plugin.microsoft365.sharepoint
+
+tasks:
+  - id: delete-file
+    type: io.kestra.plugin.microsoft365.sharepoint.Delete
+    siteId: "{{ secret('SHAREPOINT_SITE_ID') }}"
+    driveId: "{{ secret('SHAREPOINT_DRIVE_ID') }}"
+    itemId: "{{ secret('SHAREPOINT_ITEM_ID') }}"

--- a/src/test/resources/flows/sharepoint/download.yaml
+++ b/src/test/resources/flows/sharepoint/download.yaml
@@ -1,0 +1,9 @@
+id: sharepoint-download
+namespace: io.kestra.plugin.microsoft365.sharepoint
+
+tasks:
+  - id: download-file
+    type: io.kestra.plugin.microsoft365.sharepoint.Download
+    siteId: "{{ secret('SHAREPOINT_SITE_ID') }}"
+    driveId: "{{ secret('SHAREPOINT_DRIVE_ID') }}"
+    itemId: "{{ secret('SHAREPOINT_ITEM_ID') }}"

--- a/src/test/resources/flows/sharepoint/export.yaml
+++ b/src/test/resources/flows/sharepoint/export.yaml
@@ -1,0 +1,10 @@
+id: sharepoint-export
+namespace: io.kestra.plugin.microsoft365.sharepoint
+
+tasks:
+  - id: export-file
+    type: io.kestra.plugin.microsoft365.sharepoint.Export
+    siteId: "{{ secret('SHAREPOINT_SITE_ID') }}"
+    driveId: "{{ secret('SHAREPOINT_DRIVE_ID') }}"
+    itemId: "{{ secret('SHAREPOINT_ITEM_ID') }}"
+    format: "pdf"

--- a/src/test/resources/flows/sharepoint/list.yaml
+++ b/src/test/resources/flows/sharepoint/list.yaml
@@ -1,0 +1,9 @@
+id: sharepoint-list
+namespace: io.kestra.plugin.microsoft365.sharepoint
+
+tasks:
+  - id: list-items
+    type: io.kestra.plugin.microsoft365.sharepoint.List
+    siteId: "{{ secret('SHAREPOINT_SITE_ID') }}"
+    driveId: "{{ secret('SHAREPOINT_DRIVE_ID') }}"
+    itemId: "{{ secret('SHAREPOINT_FOLDER_ID') }}"

--- a/src/test/resources/flows/sharepoint/upload.yaml
+++ b/src/test/resources/flows/sharepoint/upload.yaml
@@ -1,0 +1,11 @@
+id: sharepoint-upload
+namespace: io.kestra.plugin.microsoft365.sharepoint
+
+tasks:
+  - id: upload-file
+    type: io.kestra.plugin.microsoft365.sharepoint.Upload
+    siteId: "{{ secret('SHAREPOINT_SITE_ID') }}"
+    driveId: "{{ secret('SHAREPOINT_DRIVE_ID') }}"
+    parentId: "{{ secret('SHAREPOINT_PARENT_ID') }}"
+    filename: "uploaded-example.txt"
+    content: "This is an example file uploaded by Kestra"


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/11573.

##  Feature: Add SharePoint Sub-Plugin for Microsoft 365 Integration

### What changes are being made and why?

This PR introduces a new sub-plugin under the Microsoft 365 plugin:  
`io.kestra.plugin.microsoft365.sharepoint`

This sub-plugin enables **direct interaction with SharePoint sites and document libraries** via the **Microsoft Graph API**, aligning with the structure and functionality of existing integrations such as Google Drive and OneShare.

#### **Key tasks added**
- **Create** — Upload or create a file/folder.  
- **Delete** — Remove files or folders.  
- **Download** — Retrieve file content.  
- **Export** — Convert Office files to another format (e.g., PDF).  
- **List** — List contents of document libraries or folders.  
- **Upload** — Upload files (simple or chunked).

These tasks bring SharePoint parity with other supported storage systems and provide organizations with unified file management automation through Kestra workflows.

**Closes:** #11573

---

### Contributor Checklist ✅

- [x] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
