### PR TITLE
refactor: replace @slf4j with runContext.logger()

### DIFF
--- a/src/main/java/io/kestra/plugin/microsoft365/outlook/Get.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/outlook/Get.java
@@ -3,19 +3,18 @@ package io.kestra.plugin.microsoft365.outlook;
 import com.microsoft.graph.models.Attachment;
 import com.microsoft.graph.models.Message;
 import com.microsoft.graph.serviceclient.GraphServiceClient;
-import io.kestra.plugin.microsoft365.outlook.domain.AttachmentInfo;
-import io.kestra.plugin.microsoft365.outlook.domain.MessageDetail;
-import io.kestra.plugin.microsoft365.outlook.utils.GraphMailUtils;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.microsoft365.outlook.domain.AttachmentInfo;
+import io.kestra.plugin.microsoft365.outlook.domain.MessageDetail;
+import io.kestra.plugin.microsoft365.outlook.utils.GraphMailUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -23,7 +22,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-@Slf4j
 @SuperBuilder
 @ToString
 @EqualsAndHashCode


### PR DESCRIPTION
This PR removes `@Slf4j` annotations and replaces with execution-specific `runContext.logger()` where applicable.
### What changes are being made and why?

- Updated `getAttachmentContent()` method signature to accept `Logger` parameter (This method had a single usage and single logging statement using `@Slf4j`)
- Removed unused `@Slf4j` annotations from classes

Related to kestra-io/kestra#12770

---

### How the changes have been QAed?

✅ All existing unit tests pass successfully
✅ Code compiles with no errors or warnings
✅ No functional changes - refactoring only

---