### PR TITLE
fix: replace deprecated Property<> constructor with Property.ofValue/ofExpression

### DIFF
--- a/src/test/java/io/kestra/plugin/microsoft365/teams/TeamsIncomingWebhookTest.java
+++ b/src/test/java/io/kestra/plugin/microsoft365/teams/TeamsIncomingWebhookTest.java
@@ -41,7 +41,7 @@ class TeamsIncomingWebhookTest {
 
         TeamsIncomingWebhook task = TeamsIncomingWebhook.builder()
             .url(embeddedServer.getURI() + "/webhook-unit-test")
-            .payload(new Property<>(
+            .payload(Property.ofValue(
                 Files.asCharSource(
                     new File(Objects.requireNonNull(TeamsIncomingWebhookTest.class.getClassLoader()
                             .getResource("teams.peb"))

--- a/src/test/java/io/kestra/plugin/microsoft365/teams/TeamsIncomingWebhookTest.java
+++ b/src/test/java/io/kestra/plugin/microsoft365/teams/TeamsIncomingWebhookTest.java
@@ -41,7 +41,7 @@ class TeamsIncomingWebhookTest {
 
         TeamsIncomingWebhook task = TeamsIncomingWebhook.builder()
             .url(embeddedServer.getURI() + "/webhook-unit-test")
-            .payload(Property.ofValue(
+            .payload(Property.ofExpression(
                 Files.asCharSource(
                     new File(Objects.requireNonNull(TeamsIncomingWebhookTest.class.getClassLoader()
                             .getResource("teams.peb"))


### PR DESCRIPTION
## Summary
- Replace all `new Property<>(...)` constructor calls with the appropriate factory method
- Use `Property.ofExpression(...)` when the argument contains Pebble expressions (`{{...}}`)
- Use `Property.ofValue(...)` for all other cases (literal values, variables, etc.)

The `Property<>` constructor is deprecated in favor of these explicit factory methods.