### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/microsoft365/MicrosoftGraphConnectionInterface.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/MicrosoftGraphConnectionInterface.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.microsoft365;
 
 import io.kestra.core.models.property.Property;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.kestra.core.models.annotations.PluginProperty;
 
 public interface MicrosoftGraphConnectionInterface {
     @Schema(
@@ -11,6 +12,7 @@ public interface MicrosoftGraphConnectionInterface {
                     If you don't have a service principal, refer to [create a service principal with Azure CLI](https://learn.microsoft.com/en-us/cli/azure/azure-cli-sp-tutorial-1?tabs=bash).
                     """
     )
+    @PluginProperty(group = "connection")
     Property<String> getClientId();
 
     @Schema(
@@ -21,6 +23,7 @@ public interface MicrosoftGraphConnectionInterface {
                     Either clientSecret OR pemCertificate must be provided, not both.
                     """
     )
+    @PluginProperty(group = "connection")
     Property<String> getClientSecret();
 
     @Schema(
@@ -31,8 +34,10 @@ public interface MicrosoftGraphConnectionInterface {
                 Either clientSecret OR pemCertificate must be provided, not both.
             """
     )
+    @PluginProperty(group = "advanced")
     Property<String> getPemCertificate();
 
     @Schema(title = "Tenant ID")
+    @PluginProperty(group = "connection")
     Property<String> getTenantId();
 }

--- a/src/main/java/io/kestra/plugin/microsoft365/oneshare/AbstractOneShareTask.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/oneshare/AbstractOneShareTask.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString(callSuper = true)
@@ -22,5 +23,6 @@ public abstract class AbstractOneShareTask extends AbstractGraphConnection {
         description = "OneDrive or SharePoint drive identifier required for all OneShare tasks"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> driveId;
 }

--- a/src/main/java/io/kestra/plugin/microsoft365/oneshare/Create.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/oneshare/Create.java
@@ -23,6 +23,7 @@ import lombok.experimental.SuperBuilder;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -81,6 +82,7 @@ public class Create extends AbstractOneShareTask implements RunnableTask<Create.
         title = "Parent folder ID",
         description = "Target folder ID; defaults to drive root"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> parentId;
 
     @Schema(
@@ -88,6 +90,7 @@ public class Create extends AbstractOneShareTask implements RunnableTask<Create.
         description = "Filename or folder name to create"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> name;
 
     @Schema(
@@ -95,12 +98,14 @@ public class Create extends AbstractOneShareTask implements RunnableTask<Create.
         description = "FILE (default) creates a file; FOLDER creates a folder"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<ItemType> itemType = Property.ofValue(ItemType.FILE);
 
     @Schema(
         title = "File content",
         description = "UTF-8 text to write when creating a file; ignored for folders; empty value creates zero-byte file"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> content;
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/oneshare/Delete.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/oneshare/Delete.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -78,6 +79,7 @@ public class Delete extends AbstractOneShareTask implements RunnableTask<VoidOut
         description = "DriveItem ID of the file or folder to delete"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> itemId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/oneshare/Download.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/oneshare/Download.java
@@ -21,6 +21,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -80,6 +81,7 @@ public class Download extends AbstractOneShareTask implements RunnableTask<Downl
         description = "DriveItem ID of the file to download"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> itemId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/oneshare/Export.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/oneshare/Export.java
@@ -21,6 +21,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -86,6 +87,7 @@ public class Export extends AbstractOneShareTask implements RunnableTask<Export.
         description = "DriveItem ID of the file to export"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> itemId;
 
     @Schema(
@@ -93,6 +95,7 @@ public class Export extends AbstractOneShareTask implements RunnableTask<Export.
         description = "Target format PDF or HTML; Graph limits HTML to loop/fluid/wbtx types"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<ExportFormat> format;
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/oneshare/List.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/oneshare/List.java
@@ -22,6 +22,7 @@ import lombok.experimental.SuperBuilder;
 import java.util.ArrayList;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -76,6 +77,7 @@ public class List extends AbstractOneShareTask implements RunnableTask<List.Outp
         title = "Folder ID",
         description = "DriveItem ID of the folder to list; defaults to root"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> itemId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/oneshare/Trigger.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/oneshare/Trigger.java
@@ -35,6 +35,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -128,12 +129,14 @@ public class Trigger extends AbstractMicrosoft365Trigger implements PollingTrigg
         title = "Drive ID to monitor",
         description = "Drive identifier; takes precedence when both driveId and siteId are provided"
     )
+    @PluginProperty(group = "advanced")
     protected Property<String> driveId;
 
     @Schema(
         title = "Site ID to monitor",
         description = "SharePoint site identifier used when driveId is not set"
     )
+    @PluginProperty(group = "advanced")
     protected Property<String> siteId;
 
     @Schema(
@@ -141,6 +144,7 @@ public class Trigger extends AbstractMicrosoft365Trigger implements PollingTrigg
         description = "Absolute path starting with '/' (e.g., /Documents)"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> path;
 
     @Schema(
@@ -148,6 +152,7 @@ public class Trigger extends AbstractMicrosoft365Trigger implements PollingTrigg
         description = "ISO-8601 duration between delta checks; default PT1M"
     )
     @Builder.Default
+    @PluginProperty(group = "execution")
     private Duration interval = Duration.ofMinutes(1);
 
     @Schema(
@@ -161,12 +166,14 @@ public class Trigger extends AbstractMicrosoft365Trigger implements PollingTrigg
         title = "State key",
         description = "Key for persisted trigger state; defaults to `<namespace>__<flowId>__<triggerId>`"
     )
+    @PluginProperty(group = "connection")
     protected Property<String> stateKey;
 
     @Schema(
         title = "State TTL",
         description = "TTL for persisted state entries (e.g., PT24H, P7D); default 7 days"
     )
+    @PluginProperty(group = "advanced")
     protected Property<Duration> stateTtl;
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/oneshare/Upload.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/oneshare/Upload.java
@@ -122,6 +122,7 @@ public class Upload extends AbstractOneShareTask implements RunnableTask<Upload.
         description = "Target folder ID; defaults to drive root"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> parentId = Property.ofValue("root");
 
     @Schema(
@@ -129,6 +130,7 @@ public class Upload extends AbstractOneShareTask implements RunnableTask<Upload.
         description = "Filename to create in OneDrive/SharePoint; can differ from source name"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> fileName;
 
     @Schema(
@@ -136,7 +138,7 @@ public class Upload extends AbstractOneShareTask implements RunnableTask<Upload.
         description = "URI in Kestra internal storage to upload (inputs/outputs/other tasks)"
     )
     @NotNull
-    @PluginProperty(internalStorageURI = true)
+    @PluginProperty(internalStorageURI = true, group = "main")
     private Property<String> from;
 
     @Schema(
@@ -144,6 +146,7 @@ public class Upload extends AbstractOneShareTask implements RunnableTask<Upload.
         description = "Bytes threshold to switch to resumable upload; default 4MB (4194304)"
     )
     @Builder.Default
+    @PluginProperty(group = "source")
     private Property<Long> largeFileThreshold = Property.ofValue(DEFAULT_LARGE_FILE_THRESHOLD);
 
     @Schema(
@@ -151,6 +154,7 @@ public class Upload extends AbstractOneShareTask implements RunnableTask<Upload.
         description = "Chunk size in bytes for resumable upload; must be multiple of 320 KiB; default 3,276,800"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Integer> maxSliceSize = Property.ofValue(DEFAULT_MAX_SLICE_SIZE);
 
     @Schema(
@@ -158,6 +162,7 @@ public class Upload extends AbstractOneShareTask implements RunnableTask<Upload.
         description = "Maximum retries for chunk uploads; default 5"
     )
     @Builder.Default
+    @PluginProperty(group = "reliability")
     private Property<Integer> maxRetryAttempts = Property.ofValue(DEFAULT_MAX_RETRY_ATTEMPTS);
 
     @Schema(
@@ -165,6 +170,7 @@ public class Upload extends AbstractOneShareTask implements RunnableTask<Upload.
         description = "How to handle existing files: REPLACE (default), FAIL, or RENAME"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<ConflictBehavior> conflictBehavior = Property.ofValue(ConflictBehavior.REPLACE);
 
     public enum ConflictBehavior {

--- a/src/main/java/io/kestra/plugin/microsoft365/outlook/AbstractMicrosoftGraphIdentityConnection.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/outlook/AbstractMicrosoftGraphIdentityConnection.java
@@ -13,6 +13,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.util.Optional;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -22,21 +23,26 @@ import java.util.Optional;
 public abstract class AbstractMicrosoftGraphIdentityConnection extends Task {
     @Schema(title = "Azure tenant ID", description = "Entra tenant (directory) ID used for Graph auth")
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> tenantId;
 
     @Schema(title = "Azure client ID", description = "Application (client) ID of the Graph app registration")
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> clientId;
 
     @Schema(title = "Azure client secret", description = "Client secret for the app registration; required for client-credentials flow")
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> clientSecret;
 
     @Schema(title = "User principal name", description = "Mailbox UPN/email to act on; defaults to app context when omitted")
+    @PluginProperty(group = "advanced")
     protected Property<String> userPrincipalName;
 
     @Schema(title = "Scopes", description = "Space-separated Graph scopes; default uses `.default` application permissions")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     protected Property<String> scopes = Property.ofValue("https://graph.microsoft.com/.default");
 
     protected GraphServiceClient createGraphClient(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/microsoft365/outlook/AbstractMicrosoftGraphIdentityPollingTrigger.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/outlook/AbstractMicrosoftGraphIdentityPollingTrigger.java
@@ -15,6 +15,7 @@ import lombok.experimental.SuperBuilder;
 
 import java.time.Duration;
 import java.util.Optional;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -24,25 +25,31 @@ import java.util.Optional;
 public abstract class AbstractMicrosoftGraphIdentityPollingTrigger extends AbstractTrigger implements PollingTriggerInterface {
     @Schema(title = "Azure tenant ID", description = "Entra tenant (directory) ID used for Graph auth")
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> tenantId;
 
     @Schema(title = "Azure client ID", description = "Application (client) ID of the Graph app registration")
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> clientId;
 
     @Schema(title = "Azure client secret", description = "Client secret for the app registration; required for client-credentials flow")
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> clientSecret;
 
     @Schema(title = "User principal name", description = "Mailbox UPN/email to act on; defaults to app context when omitted")
+    @PluginProperty(group = "advanced")
     protected Property<String> userPrincipalName;
 
     @Schema(title = "Scopes", description = "Space-separated Graph scopes; default uses `.default` application permissions")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     protected Property<String> scopes = Property.ofValue("https://graph.microsoft.com/.default");
 
     @Schema(title = "Polling interval", description = "ISO-8601 duration between polls; default PT5M")
     @Builder.Default
+    @PluginProperty(group = "execution")
     protected Duration interval = Duration.ofMinutes(5);
 
     protected GraphServiceClient createGraphClient(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/microsoft365/outlook/Get.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/outlook/Get.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -79,6 +80,7 @@ public class Get extends AbstractMicrosoftGraphIdentityConnection implements Run
         description = "Graph message ID to retrieve"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> messageId;
 
     @Schema(
@@ -86,12 +88,14 @@ public class Get extends AbstractMicrosoftGraphIdentityConnection implements Run
         description = "If true, returns attachment metadata; content is not downloaded here"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> includeAttachments = Property.ofValue(false);
 
     @Schema(
         title = "User email",
         description = "Mailbox to read; defaults to app mailbox when omitted"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> userEmail;
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/outlook/List.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/outlook/List.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -104,12 +105,14 @@ public class List extends AbstractMicrosoftGraphIdentityConnection implements Ru
         description = "Folder to read (inbox, sentitems, drafts, deleteditems, or folder ID)",
         defaultValue = "inbox"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> folderId;
 
     @Schema(
         title = "Filter",
         description = "OData filter expression (e.g., isRead eq false, from/emailAddress/address eq 'sender@example.com')"
     )
+    @PluginProperty(group = "processing")
     private Property<String> filter;
 
     @Schema(
@@ -117,6 +120,7 @@ public class List extends AbstractMicrosoftGraphIdentityConnection implements Ru
         description = "Maximum number of messages to return in this call",
         defaultValue = "50"
     )
+    @PluginProperty(group = "destination")
     private Property<Integer> top;
 
     @Schema(
@@ -124,6 +128,7 @@ public class List extends AbstractMicrosoftGraphIdentityConnection implements Ru
         description = "Mailbox to monitor; if not specified, uses the authenticated user's mailbox."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> userEmail;
 
     @Schema(
@@ -136,6 +141,7 @@ public class List extends AbstractMicrosoftGraphIdentityConnection implements Ru
     )
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "processing")
     private Property<FetchType> fetchType = Property.ofValue(FetchType.FETCH);
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/outlook/MailReceivedTrigger.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/outlook/MailReceivedTrigger.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 
 import static io.kestra.core.models.triggers.StatefulTriggerService.*;
 import static io.kestra.core.utils.Rethrow.throwFunction;
+import io.kestra.core.models.annotations.PluginProperty;
 
 
 @SuperBuilder
@@ -138,6 +139,7 @@ public class MailReceivedTrigger extends AbstractMicrosoftGraphIdentityPollingTr
         title = "Polling interval",
         description = "ISO-8601 duration between polls; default PT5M"
     )
+    @PluginProperty(group = "execution")
     private final Duration interval = Duration.ofMinutes(5);
 
     @Schema(
@@ -145,18 +147,21 @@ public class MailReceivedTrigger extends AbstractMicrosoftGraphIdentityPollingTr
         description = "Mailbox folder to monitor (e.g., inbox, drafts, sentitems, deleteditems, or folder ID)"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> folderId = Property.ofValue("inbox");
 
     @Schema(
         title = "User email",
         description = "Mailbox to monitor; if not specified, uses the authenticated user's mailbox."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> userEmail;
 
     @Schema(
         title = "OData filter",
         description = "Graph OData filter, e.g., `from/emailAddress/address eq sender@example.com` or `hasAttachments eq true`"
     )
+    @PluginProperty(group = "processing")
     private Property<String> filter;
 
     @Schema(
@@ -164,6 +169,7 @@ public class MailReceivedTrigger extends AbstractMicrosoftGraphIdentityPollingTr
         description = "If true, downloads file attachments to Kestra internal storage"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> includeAttachments = Property.ofValue(false);
 
     @Schema(
@@ -171,18 +177,21 @@ public class MailReceivedTrigger extends AbstractMicrosoftGraphIdentityPollingTr
         description = "Maximum messages processed each poll"
     )
     @Builder.Default
+    @PluginProperty(group = "execution")
     private Property<Integer> maxMessages = Property.ofValue(10);
 
     @Schema(
         title = "State key",
         description = "Custom key for persisted state; defaults to trigger ID"
     )
+    @PluginProperty(group = "connection")
     private Property<String> stateKey;
 
     @Schema(
         title = "State TTL",
         description = "TTL for state entries (e.g., PT24H, P30D); after expiry messages may retrigger"
     )
+    @PluginProperty(group = "advanced")
     private Property<Duration> stateTtl;
 
     @Override
@@ -388,48 +397,63 @@ public class MailReceivedTrigger extends AbstractMicrosoftGraphIdentityPollingTr
     @Getter
     public static class EmailMessage {
         @Schema(title = "Message ID")
+        @PluginProperty(group = "advanced")
         private final String id;
 
         @Schema(title = "Email subject")
+        @PluginProperty(group = "advanced")
         private final String subject;
 
         @Schema(title = "Sender email address")
+        @PluginProperty(group = "source")
         private final String from;
 
         @Schema(title = "Sender name")
+        @PluginProperty(group = "advanced")
         private final String fromName;
 
         @Schema(title = "To recipients")
+        @PluginProperty(group = "advanced")
         private final List<String> toRecipients;
 
         @Schema(title = "CC recipients")
+        @PluginProperty(group = "advanced")
         private final List<String> ccRecipients;
 
         @Schema(title = "Date and time the message was received")
+        @PluginProperty(group = "advanced")
         private final ZonedDateTime receivedDateTime;
 
         @Schema(title = "Date and time the message was sent")
+        @PluginProperty(group = "advanced")
         private final ZonedDateTime sentDateTime;
 
         @Schema(title = "Whether the message has attachments")
+        @PluginProperty(group = "advanced")
         private final Boolean hasAttachments;
 
         @Schema(title = "Whether the message has been read")
+        @PluginProperty(group = "advanced")
         private final Boolean isRead;
 
         @Schema(title = "Message importance (Low, Normal, High)")
+        @PluginProperty(group = "advanced")
         private final String importance;
 
         @Schema(title = "Preview of the message body")
+        @PluginProperty(group = "advanced")
         private final String bodyPreview;
 
         @Schema(title = "Full message body content")
+        @PluginProperty(group = "advanced")
         private final String body;
 
         @Schema(title = "Body content type (Text or HTML)")
+        @PluginProperty(group = "advanced")
         private final String bodyContentType;
 
         @Schema(title = "List of attachments with URIs to stored files in Kestra")
+        @PluginProperty(group = "advanced")
         private final List<AttachmentData> attachments;
     }
 
@@ -437,21 +461,27 @@ public class MailReceivedTrigger extends AbstractMicrosoftGraphIdentityPollingTr
     @Getter
     public static class AttachmentData {
         @Schema(title = "Attachment ID")
+        @PluginProperty(group = "advanced")
         private final String id;
 
         @Schema(title = "Attachment name")
+        @PluginProperty(group = "advanced")
         private final String name;
 
         @Schema(title = "Content type")
+        @PluginProperty(group = "advanced")
         private final String contentType;
 
         @Schema(title = "Size in bytes")
+        @PluginProperty(group = "advanced")
         private final Integer size;
 
         @Schema(title = "Whether the attachment is inline")
+        @PluginProperty(group = "advanced")
         private final Boolean isInline;
 
         @Schema(title = "URI to the downloaded attachment in Kestra's internal storage")
+        @PluginProperty(group = "advanced")
         private final URI uri;
     }
 }

--- a/src/main/java/io/kestra/plugin/microsoft365/outlook/Send.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/outlook/Send.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -117,18 +118,21 @@ public class Send extends AbstractMicrosoftGraphIdentityConnection implements Ru
         description = "Email addresses for To"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<List<String>> to;
 
     @Schema(
         title = "CC recipients",
         description = "Email addresses for CC"
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> cc;
 
     @Schema(
         title = "BCC recipients",
         description = "Email addresses for BCC"
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> bcc;
 
     @Schema(
@@ -136,6 +140,7 @@ public class Send extends AbstractMicrosoftGraphIdentityConnection implements Ru
         description = "Subject line"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> subject;
 
     @Schema(
@@ -143,12 +148,14 @@ public class Send extends AbstractMicrosoftGraphIdentityConnection implements Ru
         description = "Body content"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> body;
 
     @Schema(
         title = "Body type",
         description = "Content type for body (Html or Text); defaults to Html"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> bodyType;
 
     @Schema(
@@ -156,6 +163,7 @@ public class Send extends AbstractMicrosoftGraphIdentityConnection implements Ru
         description = "Sender mailbox address used for Graph `sendMail`"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> from;
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/AbstractSharepointTask.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/AbstractSharepointTask.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -23,6 +24,7 @@ public abstract class AbstractSharepointTask extends Task {
         description = "Azure AD (Entra ID) tenant GUID used for Graph authentication"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> tenantId;
 
     @Schema(
@@ -30,6 +32,7 @@ public abstract class AbstractSharepointTask extends Task {
         description = "Application (client) ID of the registered Entra ID app"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> clientId;
 
     @Schema(
@@ -37,6 +40,7 @@ public abstract class AbstractSharepointTask extends Task {
         description = "Client secret for the app registration; required for client-credentials flow"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> clientSecret;
 
     @Schema(
@@ -44,12 +48,14 @@ public abstract class AbstractSharepointTask extends Task {
         description = "Site identifier in Graph format `hostname,siteId,webId`"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> siteId;
 
     @Schema(
         title = "Drive ID",
         description = "Document library ID; if omitted the first drive returned for the site is used"
     )
+    @PluginProperty(group = "advanced")
     protected Property<String> driveId;
 
     protected SharepointConnection connection(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Create.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Create.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -73,6 +74,7 @@ public class Create extends AbstractSharepointTask implements RunnableTask<Creat
             description = "Target folder ID; use 'root' for the document library root"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> parentId;
 
     @Schema(
@@ -80,6 +82,7 @@ public class Create extends AbstractSharepointTask implements RunnableTask<Creat
         description = "Filename or folder name to create"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> name;
 
     @Schema(
@@ -88,12 +91,14 @@ public class Create extends AbstractSharepointTask implements RunnableTask<Creat
     )
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<ItemType> itemType = Property.ofValue(ItemType.FILE);
 
     @Schema(
         title = "File content",
         description = "String content for the new file; ignored for folders; empty value results in a zero-byte file"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> content;
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Delete.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Delete.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -49,6 +50,7 @@ public class Delete extends AbstractSharepointTask implements RunnableTask<Delet
         description = "Unique identifier of the file or folder to delete"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> itemId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Download.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Download.java
@@ -15,6 +15,7 @@ import lombok.experimental.SuperBuilder;
 
 import java.io.InputStream;
 import java.net.URI;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -71,12 +72,14 @@ public class Download extends AbstractSharepointTask implements RunnableTask<Dow
         title = "Item ID",
         description = "ID of the file to download; either itemId or itemPath is required"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> itemId;
 
     @Schema(
         title = "Item path",
         description = "Path relative to the drive root (e.g., '/Documents/file.txt'); either itemPath or itemId is required"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> itemPath;
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Export.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Export.java
@@ -14,6 +14,7 @@ import lombok.experimental.SuperBuilder;
 
 import java.io.InputStream;
 import java.net.URI;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -71,12 +72,14 @@ public class Export extends AbstractSharepointTask implements RunnableTask<Expor
         title = "Item ID",
         description = "ID of the file to export; either itemId or itemPath is required"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> itemId;
 
     @Schema(
         title = "Item path",
         description = "Path relative to the drive root (e.g., '/Documents/file.docx'); either itemPath or itemId is required"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> itemPath;
 
     @Schema(
@@ -84,6 +87,7 @@ public class Export extends AbstractSharepointTask implements RunnableTask<Expor
         description = "Conversion target; supported values are PDF or HTML"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<FormatType> format;
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/List.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/List.java
@@ -28,6 +28,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Objects;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -94,6 +95,7 @@ public class List extends AbstractSharepointTask implements RunnableTask<List.Ou
     )
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> folderId = Property.ofValue("root");
 
     @Schema(
@@ -106,6 +108,7 @@ public class List extends AbstractSharepointTask implements RunnableTask<List.Ou
     )
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "processing")
     private Property<FetchType> fetchType = Property.ofValue(FetchType.FETCH);
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Move.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Move.java
@@ -15,6 +15,7 @@ import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
 
 import java.util.Objects;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -56,6 +57,7 @@ public class Move extends AbstractSharepointTask implements RunnableTask<Move.Ou
         description = "Unique identifier of the file or folder to move"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> itemId;
 
     @Schema(
@@ -63,12 +65,14 @@ public class Move extends AbstractSharepointTask implements RunnableTask<Move.Ou
         description = "ID of the destination folder (parent) to move the item into"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> destinationParentId;
 
     @Schema(
         title = "New name",
         description = "Optional new name for the moved item"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> newName;
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/SharepointConnection.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/SharepointConnection.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.Objects;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @Builder
@@ -22,6 +23,7 @@ public class SharepointConnection {
         description = "Azure AD (Entra ID) tenant GUID used for Graph authentication"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> tenantId;
 
     @Schema(
@@ -29,6 +31,7 @@ public class SharepointConnection {
         description = "Application (client) ID of the registered Entra ID app"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> clientId;
 
     @Schema(
@@ -36,6 +39,7 @@ public class SharepointConnection {
         description = "Client secret for the app registration; required for client-credentials flow"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> clientSecret;
 
     @Schema(
@@ -43,12 +47,14 @@ public class SharepointConnection {
         description = "Site identifier in Graph format `hostname,siteId,webId`"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> siteId;
 
     @Schema(
         title = "Drive ID",
         description = "Document library ID; if omitted the first drive returned for the site is used"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> driveId;
 
     public GraphServiceClient createClient(RunContext runContext) throws Exception{

--- a/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Upload.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/sharepoint/Upload.java
@@ -14,6 +14,7 @@ import lombok.experimental.SuperBuilder;
 import jakarta.validation.constraints.NotNull;
 import java.io.InputStream;
 import java.net.URI;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -76,6 +77,7 @@ public class Upload extends AbstractSharepointTask implements RunnableTask<Uploa
         description = "URI of the file in Kestra internal storage to upload"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> from;
 
     @Schema(
@@ -83,6 +85,7 @@ public class Upload extends AbstractSharepointTask implements RunnableTask<Uploa
         description = "Filename to create in SharePoint"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> to;
 
     @Schema(
@@ -91,6 +94,7 @@ public class Upload extends AbstractSharepointTask implements RunnableTask<Uploa
     )
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> parentId = Property.ofValue("root");
 
     @Schema(
@@ -98,6 +102,7 @@ public class Upload extends AbstractSharepointTask implements RunnableTask<Uploa
         description = "Reserved flag for naming conflicts; currently ignored and the upload overwrites existing files"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private ConflictBehavior conflictBehavior = ConflictBehavior.FAIL;
 
     @Schema(
@@ -105,6 +110,7 @@ public class Upload extends AbstractSharepointTask implements RunnableTask<Uploa
         description = "Unused placeholder for chunked uploads; Graph simple upload is used instead"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Long> chunkSize = Property.ofValue(5L * 1024 * 1024); // 5MB
 
     private static final long SIMPLE_UPLOAD_SIZE_LIMIT = 4L * 1024 * 1024; // 4MB

--- a/src/main/java/io/kestra/plugin/microsoft365/teams/AbstractTeamsConnection.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/teams/AbstractTeamsConnection.java
@@ -30,7 +30,7 @@ public abstract class AbstractTeamsConnection extends Task implements RunnableTa
         title = "HTTP client options",
         description = "Optional timeouts, charset, headers, and limits for Teams webhook calls"
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     protected RequestOptions options;
 
     protected HttpConfiguration httpClientConfigurationWithOptions() throws IllegalVariableEvaluationException {
@@ -69,32 +69,39 @@ public abstract class AbstractTeamsConnection extends Task implements RunnableTa
     @Builder
     public static class RequestOptions {
         @Schema(title = "The time allowed to establish a connection to the server before failing.")
+        @PluginProperty(group = "execution")
         private final Property<Duration> connectTimeout;
 
         @Schema(title = "The maximum time allowed for reading data from the server before failing.")
         @Builder.Default
+        @PluginProperty(group = "execution")
         private final Property<Duration> readTimeout = Property.ofValue(Duration.ofSeconds(10));
 
         @Schema(title = "The time allowed for a read connection to remain idle before closing it.")
         @Builder.Default
+        @PluginProperty(group = "execution")
         private final Property<Duration> readIdleTimeout = Property.ofValue(Duration.of(5, ChronoUnit.MINUTES));
 
         @Schema(title = "Idle pool timeout", description = "Time an idle connection stays in the pool before closing")
         @Builder.Default
+        @PluginProperty(group = "execution")
         private final Property<Duration> connectionPoolIdleTimeout = Property.ofValue(Duration.ofSeconds(0));
 
         @Schema(title = "Max response size", description = "Maximum response content length in bytes")
         @Builder.Default
+        @PluginProperty(group = "execution")
         private final Property<Integer> maxContentLength = Property.ofValue(1024 * 1024 * 10);
 
         @Schema(title = "Default charset")
         @Builder.Default
+        @PluginProperty(group = "advanced")
         private final Property<Charset> defaultCharset = Property.ofValue(StandardCharsets.UTF_8);
 
         @Schema(
             title = "HTTP headers",
             description = "HTTP headers to include in the request"
         )
+        @PluginProperty(group = "advanced")
         public Property<Map<String,String>> headers;
     }
 }

--- a/src/main/java/io/kestra/plugin/microsoft365/teams/TeamsExecution.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/teams/TeamsExecution.java
@@ -12,6 +12,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.util.Map;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -56,8 +57,11 @@ import java.util.Map;
 )
 public class TeamsExecution extends TeamsTemplate implements ExecutionInterface {
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private final Property<String> executionId = Property.ofExpression("{{ execution.id }}");
+    @PluginProperty(group = "destination")
     private Property<Map<String, Object>> customFields;
+    @PluginProperty(group = "destination")
     private Property<String> customMessage;
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/teams/TeamsIncomingWebhook.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/teams/TeamsIncomingWebhook.java
@@ -140,7 +140,7 @@ public class TeamsIncomingWebhook  extends AbstractTeamsConnection {
     @Schema(
         title = "Teams incoming webhook URL"
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "main")
     @NotEmpty
     private String url;
 
@@ -148,6 +148,7 @@ public class TeamsIncomingWebhook  extends AbstractTeamsConnection {
         title = "Teams message payload",
         description = "Raw JSON payload for the webhook (Adaptive Card or MessageCard)"
     )
+    @PluginProperty(group = "main")
     protected Property<String> payload;
 
     @Override

--- a/src/main/java/io/kestra/plugin/microsoft365/teams/TeamsTemplate.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/teams/TeamsTemplate.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -24,22 +25,27 @@ public abstract class TeamsTemplate extends TeamsIncomingWebhook {
         title = "Template to use",
         hidden = true
     )
+    @PluginProperty(group = "advanced")
     protected Property<String> templateUri;
 
     @Schema(
         title = "Template variables",
         description = "Key-value map rendered into the template before sending"
     )
+    @PluginProperty(group = "advanced")
     protected Property<Map<String, Object>> templateRenderMap;
 
     @Schema(title = "Theme color")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     protected Property<String> themeColor = Property.ofValue("0076D7");
 
     @Schema(title = "Activity title")
+    @PluginProperty(group = "advanced")
     protected Property<String> activityTitle;
 
     @Schema(title = "Activity subtitle")
+    @PluginProperty(group = "advanced")
     protected Property<String> activitySubtitle;
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712