### PR TITLE
refactor: update deprecated task identifiers in examples

### DIFF
--- a/src/main/java/io/kestra/plugin/microsoft365/oneshare/Trigger.java
+++ b/src/main/java/io/kestra/plugin/microsoft365/oneshare/Trigger.java
@@ -57,7 +57,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 
                 tasks:
                   - id: log_new_file
-                    type: io.kestra.core.tasks.log.Log
+                    type: io.kestra.plugin.core.log.Log
                     message: "New file detected: {{ trigger.files[0].name }}"
 
                 triggers:
@@ -80,7 +80,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 
                 tasks:
                   - id: log_updated_file
-                    type: io.kestra.core.tasks.log.Log
+                    type: io.kestra.plugin.core.log.Log
                     message: "File updated: {{ trigger.files[0].name }}"
 
                 triggers:
@@ -104,7 +104,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 
                 tasks:
                   - id: log_file_changes
-                    type: io.kestra.core.tasks.log.Log
+                    type: io.kestra.plugin.core.log.Log
                     message: "File changed: {{ trigger.files[0].name }}"
 
                 triggers:

--- a/src/test/resources/flows/common/main-flow-that-fails.yaml
+++ b/src/test/resources/flows/common/main-flow-that-fails.yaml
@@ -2,4 +2,4 @@ id: main-flow-that-fails
 namespace: io.kestra.tests
 tasks:
   - id: failed
-    type: io.kestra.core.tasks.executions.Fail
+    type: io.kestra.plugin.core.execution.Fail


### PR DESCRIPTION
Updates the deprecated task identifiers in the examples to their current names